### PR TITLE
Move PVE to Mikrotik native lan.

### DIFF
--- a/terraform/snmp.tf
+++ b/terraform/snmp.tf
@@ -27,7 +27,7 @@ resource "routeros_snmp_community" "test_rb5009-01" {
 }
 resource "routeros_snmp_community" "aggrik8s_rb5009-01" {
   provider = routeros.rb5009-01
-  addresses = ["192.168.88.50", "192.168.88.21", "192.168.15.27", "192.168.10.10"]
+  addresses = ["192.168.88.50", "192.168.88.51", "192.168.88.21", "192.168.15.27", "192.168.10.10"]
   name      = "aggrik8s"
 }
 
@@ -60,7 +60,7 @@ resource "routeros_snmp_community" "test_rb5009-02" {
 }
 resource "routeros_snmp_community" "aggrik8s_rb5009-02" {
   provider = routeros.rb5009-02
-  addresses = ["192.168.88.50", "192.168.88.21", "192.168.15.27", "192.168.10.10"]
+  addresses = ["192.168.88.50", "192.168.88.51", "192.168.88.21", "192.168.15.27", "192.168.10.10"]
   name      = "aggrik8s"
 }
 
@@ -93,7 +93,7 @@ resource "routeros_snmp_community" "test_crs305-01" {
 }
 resource "routeros_snmp_community" "aggrik8s_crs305-01" {
   provider = routeros.crs305-01
-  addresses = ["192.168.88.50", "192.168.88.21", "192.168.15.27", "192.168.10.10"]
+  addresses = ["192.168.88.50", "192.168.88.51", "192.168.88.21", "192.168.15.27", "192.168.10.10"]
   name      = "aggrik8s"
 }
 
@@ -126,6 +126,6 @@ resource "routeros_snmp_community" "test_crs328-01" {
 }
 resource "routeros_snmp_community" "aggrik8s_crs328-01" {
   provider = routeros.crs328-01
-  addresses = ["192.168.88.50", "192.168.88.21", "192.168.15.27", "192.168.10.10"]
+  addresses = ["192.168.88.50", "192.168.88.51", "192.168.88.21", "192.168.15.27", "192.168.10.10"]
   name      = "aggrik8s"
 }

--- a/terraform/vlan10.tf
+++ b/terraform/vlan10.tf
@@ -58,8 +58,8 @@ resource "routeros_interface_bridge_vlan" "vlan10_crs328-01" {
   provider   = routeros.crs328-01
   bridge     = routeros_interface_bridge.crs328-01.name
   vlan_ids   = [routeros_interface_vlan.crs328-01_vlan-10.vlan_id]
-  tagged     = [routeros_interface_vlan.crs328-01_vlan-10.interface, "ether8", "sfp-sfpplus2", "sfp-sfpplus3", "sfp-sfpplus4"]
-  untagged   = ["ether9", "ether10", "ether11", "ether12", "ether13", "ether14", "ether15", "ether16", "sfp-sfpplus1"]
+  tagged     = [routeros_interface_vlan.crs328-01_vlan-10.interface, "ether8",  "sfp-sfpplus1", "sfp-sfpplus2", "sfp-sfpplus3", "sfp-sfpplus4"]
+  untagged   = ["ether9", "ether10", "ether11", "ether12", "ether13", "ether14", "ether15", "ether16"]
 }
 
 resource "routeros_interface_vlan" "rb5009-01_vlan-10" {

--- a/terraform/vlan1500.tf
+++ b/terraform/vlan1500.tf
@@ -135,7 +135,7 @@ resource "routeros_interface_bridge_vlan" "vlan1500_crs328-01" {
   provider   = routeros.crs328-01
   bridge     = routeros_interface_bridge.crs328-01.name
   vlan_ids   = [routeros_interface_vlan.crs328-01_vlan-1500.vlan_id]
-  tagged     = [routeros_interface_vlan.crs328-01_vlan-1500.interface,  "ether8", "sfp-sfpplus1", "sfp-sfpplus3", "sfp-sfpplus4"]
+  tagged     = [routeros_interface_vlan.crs328-01_vlan-1500.interface, "ether6", "ether8", "sfp-sfpplus1", "sfp-sfpplus3", "sfp-sfpplus4"]
   untagged   = ["ether5"]        # Example port
 }
 

--- a/terraform/vlan2000.tf
+++ b/terraform/vlan2000.tf
@@ -103,7 +103,7 @@ resource "routeros_interface_bridge_vlan" "vlan2000_crs328-01" {
   provider   = routeros.crs328-01
   bridge     = routeros_interface_bridge.crs328-01.name
   vlan_ids   = [routeros_interface_vlan.crs328-01_vlan-2000.vlan_id]
-  tagged     = [routeros_interface_vlan.crs328-01_vlan-2000.interface, "ether8", "sfp-sfpplus1",  "sfp-sfpplus2", "sfp-sfpplus3", "sfp-sfpplus4"]
+  tagged     = [routeros_interface_vlan.crs328-01_vlan-2000.interface, "ether6", "ether8", "sfp-sfpplus1",  "sfp-sfpplus2", "sfp-sfpplus3", "sfp-sfpplus4"]
   untagged   = ["ether7"]        # Example port
 }
 


### PR DESCRIPTION
Originally, PVE was set up at 192.168.10.10 which is reserv ed for `piCluster`.

Move PVE to `192.168.88.10` and fix up VLAN tagging for `pi-manage-01` on 1500 & 2000.